### PR TITLE
use the secure handler for both inputs due to a bug in ant 1.8.2.  

### DIFF
--- a/release/jbossas/distribution/src/main/jbossas/profiles/client/build.xml
+++ b/release/jbossas/distribution/src/main/jbossas/profiles/client/build.xml
@@ -35,6 +35,7 @@
 	    <echo message="" />
 		<input message="Please enter a valid RTGov (server) username: "
 			   addproperty="rtgov.users.client.username">
+			<handler type="secure" />
 		</input>
 		<input message="Please enter user ${rtgov.users.client.username}'s password: "
 			   addproperty="rtgov.users.client.password">


### PR DESCRIPTION
see:  RTGOV-291
