### PR TITLE
RTGOV-417: Elasticsearch Bulk API support

### DIFF
--- a/content/epn-datastore/src/main/resources/epn.json
+++ b/content/epn-datastore/src/main/resources/epn.json
@@ -27,7 +27,7 @@
                         "@class": "org.overlord.rtgov.common.elasticsearch.ElasticSearchKeyValueStore",
                         "index": "rtgov",
                         "type": "activity",
-                        "hosts": "${ElasticSearch.hosts}"
+                        "hosts": "${Elasticsearch.hosts}"
 
                     }
                 }
@@ -42,7 +42,7 @@
                         "@class": "org.overlord.rtgov.common.elasticsearch.ElasticSearchKeyValueStore",
                         "index": "rtgov",
                         "type": "responsetime",
-                        "hosts": "${ElasticSearch.hosts}"
+                        "hosts": "${Elasticsearch.hosts}"
                     }
                 }
             }
@@ -56,7 +56,7 @@
                         "@class": "org.overlord.rtgov.common.elasticsearch.ElasticSearchKeyValueStore",
                         "index": "rtgov",
                         "type": "situation",
-                        "hosts": "${ElasticSearch.hosts}"
+                        "hosts": "${Elasticsearch.hosts}"
                     }
                 }
             }

--- a/modules/common/rtgov-elasticsearch/src/main/java/org/overlord/rtgov/common/elasticsearch/ElasticSearchKeyValueStore.java
+++ b/modules/common/rtgov-elasticsearch/src/main/java/org/overlord/rtgov/common/elasticsearch/ElasticSearchKeyValueStore.java
@@ -57,7 +57,7 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
     /**
      * bulkRequest. determines how many request should be sent to elastic search in bulk instead of singular requests
      */
-    private int _bulkRequests = 0;
+    private int _bulkSize = 0;
 
     static {
         SerializationConfig config = MAPPER.getSerializationConfig()
@@ -181,21 +181,21 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
     }
 
     /**
-     * This method returns the _bulkRequests.
+     * This method returns the _bulkSize.
      *
-     * @return Returns _bulksRequests
+     * @return Returns _bulkSize
      */
-    public int getBulkRequests() {
-        return _bulkRequests;
+    public int getBulkSize() {
+        return _bulkSize;
     }
 
     /**
-     * This method sets the _bulkRequests.
+     * This method sets the _bulkSize.
      *
-     * @param bulkRequests The hosts
+     * @param bulkSize The bulkSize
      */
-    public void setBulkRequests(int bulkRequests) {
-        this._bulkRequests = bulkRequests;
+    public void setBulkSize(int bulkSize) {
+        this._bulkSize = bulkSize;
     }
 
     /**
@@ -215,7 +215,7 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
         if (_type == null) {
             throw new IllegalArgumentException("Type property not set ");
         }
-        if (_bulkRequests > 0) {
+        if (_bulkSize > 0) {
             _bulkRequestsEnable = true;
             _scheduler = Executors.newScheduledThreadPool(1);
         }
@@ -331,9 +331,9 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
         /**
          * check if we need to persist now
          */
-        if (_bulkRequestBuilder.numberOfActions() >= _bulkRequests) {
+        if (_bulkRequestBuilder.numberOfActions() >= _bulkSize) {
             if (LOG.isLoggable(Level.INFO)) {
-                LOG.info("bulk limit reach. storing " + _bulkRequests + " items to  [" + _index + "/" + _type + "]");
+                LOG.info("bulk limit reach. storing " + _bulkSize + " items to  [" + _index + "/" + _type + "]");
             }
             storeBulkItems();
             _bulkRequestBuilder = null;
@@ -356,7 +356,7 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
                         return "Stored Bulk Items!";
 
                     }
-                },_schedule, TimeUnit.SECONDS);
+                },_schedule, TimeUnit.MILLISECONDS);
             }
 
         }
@@ -367,12 +367,12 @@ public class ElasticSearchKeyValueStore extends KeyValueStore {
     private void storeBulkItems() {
         BulkResponse bulkItemResponses = _bulkRequestBuilder.execute().actionGet();
         if (bulkItemResponses.hasFailures()) {
-            LOG.warning(" Bulk Documents{" + _bulkRequests + "} could not be created for index [" + _index + "/" + _type + "/");
+            LOG.warning(" Bulk Documents{" + _bulkSize + "} could not be created for index [" + _index + "/" + _type + "/");
 
             LOG.info("FAILED MESSAGES. " + bulkItemResponses.buildFailureMessage());
         } else {
             if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("Success storing " + _bulkRequests + " items to  [" + _index + "/" + _type + "]");
+                LOG.fine("Success storing " + _bulkSize + " items to  [" + _index + "/" + _type + "]");
             }
         }
     }

--- a/release/jbossas/distribution/src/main/jbossas/profiles/server/configuration/overlord-rtgov.properties
+++ b/release/jbossas/distribution/src/main/jbossas/profiles/server/configuration/overlord-rtgov.properties
@@ -23,9 +23,9 @@ ActiveCollectionManager.houseKeepingInterval=10000
 # Service dependency graph
 #MVELSeverityAnalyzer.scriptLocation = <Path to mvel script>
 
-ElasticSearch.hosts=localhost:9300
+Elasticsearch.hosts=localhost:9300
 #Default Elasticsearch schedule configuration.
-Elasticsearch.schedule=30
+Elasticsearch.schedule=30000
 
 
 


### PR DESCRIPTION
RTGOV-417: ElasticSearch Bulk api support. 
Added 2 additional configurable fields to ElasticSearchKeyValueStore
- _bulkRequests : if not set then no bulk api is used. Defined the max number of document to be stored locally before been pushed to ES 
- _schedule : Optional value. Required in the case when the max document is not exceed. A schedule can be configured to push documents to ES after configured amount of time. Value is in seconds. if nothing set then Rtgov.properties value "Elasticsearch.schedule" is used. default is 30. 
  - Added Elasticsearch.schedule to Rtgov.properties 
  - By default bulk is not enabled. in the default ES epn. 

Example EPN service config 

```
"services": {
                "KeyValueStore": {
                    "@class": "org.overlord.rtgov.common.elasticsearch.ElasticSearchKeyValueStore",
                    "index": "rtgov",
                    "type": "activity",
                    "hosts": "${ElasticSearch.hosts}",
                    "bulkRequests":"200",
                    "schedule":"30"
                }
```
