### PR TITLE
Set IP Bom version to 6.0.0.CR7 to avoid problems with enforcer rule on ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.jboss.integration-platform</groupId>
 		<artifactId>jboss-integration-platform-parent</artifactId>
-		<version>6.0.0-SNAPSHOT</version>
+		<version>6.0.0.CR7</version>
 	</parent>
 
 	<scm>
@@ -135,7 +135,7 @@
 			<dependency>
 				<groupId>org.jboss.integration-platform</groupId>
 				<artifactId>jboss-integration-platform-bom</artifactId>
-				<version>6.0.0-SNAPSHOT</version>
+				<version>6.0.0.CR7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/samples/jbossas/pom.xml
+++ b/samples/jbossas/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.jboss.integration-platform</groupId>
 		<artifactId>jboss-integration-platform-parent</artifactId>
-		<version>6.0.0-SNAPSHOT</version>
+		<version>6.0.0.CR7</version>
 	</parent>
 
 	<scm>
@@ -53,7 +53,7 @@
 			<dependency>
 				<groupId>org.jboss.integration-platform</groupId>
 				<artifactId>jboss-integration-platform-bom</artifactId>
-				<version>6.0.0-SNAPSHOT</version>
+				<version>6.0.0.CR7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/samples/karaf/pom.xml
+++ b/samples/karaf/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.jboss.integration-platform</groupId>
 		<artifactId>jboss-integration-platform-parent</artifactId>
-		<version>6.0.0-SNAPSHOT</version>
+		<version>6.0.0.CR7</version>
 	</parent>
 
 	<scm>
@@ -52,7 +52,7 @@
 			<dependency>
 				<groupId>org.jboss.integration-platform</groupId>
 				<artifactId>jboss-integration-platform-bom</artifactId>
-				<version>6.0.0-SNAPSHOT</version>
+				<version>6.0.0.CR7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
...inter-rtgov module dependencies, while the issue is being discussed
