### PR TITLE
Revert RTGOV-488, as drools version 6.0.1 has a package dependency issue...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 	<properties>
 		<cal10n-api.version>0.7.4</cal10n-api.version>
 		<commons.lang3.version>3.1</commons.lang3.version>
-		<drools.version>6.0.1.Final</drools.version>
+		<drools.version>6.1.0.Beta4</drools.version>
 		<elasticsearch.version>1.1.0</elasticsearch.version>
 		<errai.version>2.4.3.Final</errai.version>
 		<felix.version>2.3.7</felix.version>
@@ -77,7 +77,7 @@
         <jetty.version>6.1.25</jetty.version>
 		<jnp-client.version>5.0.3.GA</jnp-client.version>
 		<jsp-api.version>2.0</jsp-api.version>
-		<kie.version>6.0.1.Final</kie.version>
+		<kie.version>6.1.0.Beta4</kie.version>
         <lucene.version>4.7.0</lucene.version> <!-- Required to override parent bom version -->
         <org.apache.servicemix.bundles.lucene.version>4.7.0_1</org.apache.servicemix.bundles.lucene.version> <!-- Required for karaf -->
         <remoting-jmx>1.1.0.Final</remoting-jmx>


### PR DESCRIPTION
... in the 'drools-module' karaf feature, which is made optional in later versions
