### PR TITLE
RTGOV-568 reverted, as Elasticsearch 1.2.0 and higher is dependent upon ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<version.ch.qos.cal10n>0.7.4</version.ch.qos.cal10n>
 		<version.org.apache.commons.commons-lang3>3.1</version.org.apache.commons.commons-lang3>
 		<version.org.drools>6.1.0.Final</version.org.drools>
-		<version.org.elasticsearch>1.3.2</version.org.elasticsearch>
+		<version.org.elasticsearch>1.1.0</version.org.elasticsearch>
         <version.org.codehaus.enunciate>1.28</version.org.codehaus.enunciate>
 		<version.org.jboss.errai>2.4.3.Final</version.org.jboss.errai>
 		<version.org.apache.felix>2.3.7</version.org.apache.felix>
@@ -79,7 +79,7 @@
 		<version.org.jboss.naming>5.0.3.GA</version.org.jboss.naming>
 		<version.javax.servlet.jsp-api>2.0</version.javax.servlet.jsp-api>
 		<version.org.kie>6.1.0.Final</version.org.kie>
-        <version.org.apache.lucene>4.9.0</version.org.apache.lucene> <!-- Required to override parent bom version -->
+        <version.org.apache.lucene>4.7.2</version.org.apache.lucene> <!-- Required to override parent bom version -->
         <version.org.jboss.remotingjmx>1.1.0.Final</version.org.jboss.remotingjmx>
 		<version.org.overlord.overlord-commons>2.0.8.Final</version.org.overlord.overlord-commons>
 		<version.org.picketbox>4.0.19.SP4</version.org.picketbox>


### PR DESCRIPTION
...jdk 1.7. Need to remain compatible with jdk 1.6 currently
