### PR TITLE
Changing Doc link

### DIFF
--- a/distribution/overlord-rtgov-assembly/src/main/resources/Readme.txt
+++ b/distribution/overlord-rtgov-assembly/src/main/resources/Readme.txt
@@ -25,7 +25,7 @@ If no parameters are defined, then the defaults are:
     path: no default - will request path from user
 
 
-For more information on using Runtime Governance, see http://www.jboss.org/overlord/documentation/rtgov
+For more information on using Runtime Governance, see http://docs.jboss.org/overlord/rtgov/
 
 Next step - try out some of the quickstarts in the samples folder.
 


### PR DESCRIPTION
Documentation link leads to a 404, now pointing to the docs folder
