### PR TITLE
Docker image created with "docker" profile at maven build time

### DIFF
--- a/distribution/overlord-rtgov-dist-all-wildfly8/pom.xml
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/pom.xml
@@ -141,5 +141,41 @@
 			</plugin>
 		</plugins>
 	</build>
-
+	<profiles>
+		<profile>
+			<id>docker</id>
+<activation>
+      <activeByDefault>false</activeByDefault>
+    </activation>
+			<build>
+				<finalName>${project.artifactId}</finalName>
+				<plugins>
+					<plugin>
+						<groupId>com.spotify</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.1.1</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<imageName>${project.artifactId}:${project.version}</imageName>
+							<dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+							<resources>
+								<resource>
+									<targetPath>/</targetPath>
+									<directory>${project.build.directory}</directory>
+									<include>${project.artifactId}.zip</include>
+								</resource>
+							</resources>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>	
 </project>

--- a/distribution/overlord-rtgov-dist-all-wildfly8/pom.xml
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/pom.xml
@@ -144,9 +144,6 @@
 	<profiles>
 		<profile>
 			<id>docker</id>
-<activation>
-      <activeByDefault>false</activeByDefault>
-    </activation>
 			<build>
 				<finalName>${project.artifactId}</finalName>
 				<plugins>

--- a/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
@@ -12,7 +12,9 @@ RUN cd $HOME \
     && ./install.sh -Dpath=$JBOSS_HOME \
     && cp dist/governance-realm.json $JBOSS_HOME \
     && echo 'JAVA_OPTS="$JAVA_OPTS -Dkeycloak.import=$JBOSS_HOME/governance-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
+    echo "JAVA_OPTS=\"\$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0\"" >> ${JBOSS_HOME}/bin/standalone.conf \
     && cd $HOME \
     && rm -rf overlord-rtgov-dist-all-wildfly8
 
-CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0", "-c", "standalone-full.xml", "--debug"]
+ENTRYPOINT ["/opt/jboss/wildfly/bin/standalone.sh"]
+CMD ["-c", "standalone-full.xml", "--debug"]

--- a/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
@@ -11,8 +11,7 @@ RUN cd $HOME \
     && cd overlord-rtgov-dist-all-wildfly8 \
     && ./install.sh -Dpath=$JBOSS_HOME \
     && cp dist/governance-realm.json $JBOSS_HOME \
-    && echo 'JAVA_OPTS="$JAVA_OPTS -Dkeycloak.import=$JBOSS_HOME/governance-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
-    echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0"' >> ${JBOSS_HOME}/bin/standalone.conf \
+    && echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0 -Dkeycloak.import=$JBOSS_HOME/governance-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
     && cd $HOME \
     && rm -rf overlord-rtgov-dist-all-wildfly8
 

--- a/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN cd $HOME \
     && ./install.sh -Dpath=$JBOSS_HOME \
     && cp dist/governance-realm.json $JBOSS_HOME \
     && echo 'JAVA_OPTS="$JAVA_OPTS -Dkeycloak.import=$JBOSS_HOME/governance-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
-    echo "JAVA_OPTS=\"\$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0\"" >> ${JBOSS_HOME}/bin/standalone.conf \
+    echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0"' >> ${JBOSS_HOME}/bin/standalone.conf \
     && cd $HOME \
     && rm -rf overlord-rtgov-dist-all-wildfly8
 

--- a/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-all-wildfly8/src/main/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM jboss/wildfly:8.1.0.Final
+
+RUN $JBOSS_HOME/bin/add-user.sh admin admin123! --silent
+
+EXPOSE 8787
+
+ADD overlord-rtgov-dist-all-wildfly8.zip /tmp/
+
+RUN cd $HOME \
+    && bsdtar -xf /tmp/overlord-rtgov-dist-all-wildfly8.zip \
+    && cd overlord-rtgov-dist-all-wildfly8 \
+    && ./install.sh -Dpath=$JBOSS_HOME \
+    && cp dist/governance-realm.json $JBOSS_HOME \
+    && echo 'JAVA_OPTS="$JAVA_OPTS -Dkeycloak.import=$JBOSS_HOME/governance-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
+    && cd $HOME \
+    && rm -rf overlord-rtgov-dist-all-wildfly8
+
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0", "-c", "standalone-full.xml", "--debug"]

--- a/distribution/overlord-rtgov-dist-client-wildfly8/pom.xml
+++ b/distribution/overlord-rtgov-dist-client-wildfly8/pom.xml
@@ -97,4 +97,39 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>docker</id>
+			<build>
+				<finalName>${project.artifactId}</finalName>
+				<plugins>
+					<plugin>
+						<groupId>com.spotify</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.1.1</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<imageName>${project.artifactId}:${project.version}</imageName>
+							<dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+							<resources>
+								<resource>
+									<targetPath>/</targetPath>
+									<directory>${project.build.directory}</directory>
+									<include>${project.artifactId}.zip</include>
+								</resource>
+							</resources>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>	
+
 </project>

--- a/distribution/overlord-rtgov-dist-client-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-client-wildfly8/src/main/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM jboss/switchyard-wildfly:2.0.0.Beta1
+
+RUN $JBOSS_HOME/bin/add-user.sh admin admin123! --silent
+
+EXPOSE 8787
+
+ADD overlord-rtgov-dist-client-wildfly8.zip /tmp/
+
+RUN cd $HOME \
+    && bsdtar -xf /tmp/overlord-rtgov-dist-client-wildfly8.zip \
+    && cd overlord-rtgov-dist-client-wildfly8 \
+    && ./install.sh -Dpath=$JBOSS_HOME \
+    && echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0"' >> $JBOSS_HOME/bin/standalone.conf \
+    && cd $HOME \
+    && rm -rf overlord-rtgov-dist-client-wildfly8 \
+    && sed -i -e "s/https:\/\/rtgovserver.com:8443/http:\/\/rtgovserver:8080/g" $JBOSS_HOME/standalone/configuration/overlord-rtgov.properties \
+    && sed -i -e "s/serverPassword=admin:8443/serverPassword=admin/g" $JBOSS_HOME/standalone/configuration/overlord-rtgov.properties
+
+
+ENTRYPOINT ["/opt/jboss/wildfly/bin/standalone.sh"]
+CMD ["-c", "standalone-full.xml", "--debug"]

--- a/distribution/overlord-rtgov-dist-client-wildfly8/src/main/docker/Dockerfile
+++ b/distribution/overlord-rtgov-dist-client-wildfly8/src/main/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN cd $HOME \
 
 
 ENTRYPOINT ["/opt/jboss/wildfly/bin/standalone.sh"]
-CMD ["-c", "standalone-full.xml", "--debug"]
+CMD []


### PR DESCRIPTION
Hi,
This will create a docker image, called overlord-rtgov-dist-all-wildfly8:2.1.0-SNAPSHOT
The version will be the one used in the pom files, so will follow maven naming conventions.

You can see the images you have with:
````
docker images | grep overlord-rtgov-dist
````

Then to run the image, just do:
````
 docker run -it --rm -p 8080:8080 -p 9990:9990 -p 8787:8787 --name rtgovserver overlord-rtgov-dist-all-wildfly8:2.1.0-SNAPSHOT
````

This will have following considerations:
- a management user created (admin/admin123!)
- binding to 0.0.0.0 on the docker container, so accesible (both management and normal interfaces)
- import the governance realm at startup
- profile standalone-full.xml by default
- debug enabled on internal port 8787 (change the 8787:8787 in the docker run command line to be able to debug on a different port)

Options:
you can customize the profile or if you want debug or not by modifying the docker run command line

standalone-full-ha.xml profile and no debug
````
 docker run -it --rm -p 8080:8080 -p 9990:9990 --name rtgovserver overlord-rtgov-dist-all-wildfly8:2.1.0-SNAPSHOT -c standalone-full-ha.xml 
````

This will also create a docker image, called overlord-rtgov-dist-client-wildfly8:2.1.0-SNAPSHOT. It is a Switchyard installation (2.1.0.Beta1 ATM) and with rtgov client layered on top.

To run it, an link the client to the rtgov server, do:
````
docker run -it --rm -p 8081:8080 -p 9991:9990 --link rtgovserver:rtgovserver --name rtgovclient  overlord-rtgov-dist-client-wildfly8:2.1.0-SNAPSHOT
````

Can not use same local ports as the rtgovserver.
