### PR TITLE
RTGOV-645 Propagate 'resubmission' situation id, assignedTo and resoluti...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 .idea
 .classpath
 .project
+.tern-project
 .settings/
 .bpmn2/
 *.ipr

--- a/modules/activity-analysis/analytics/src/main/java/org/overlord/rtgov/analytics/situation/Situation.java
+++ b/modules/activity-analysis/analytics/src/main/java/org/overlord/rtgov/analytics/situation/Situation.java
@@ -34,6 +34,7 @@ import javax.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.overlord.rtgov.activity.model.ActivityTypeId;
 import org.overlord.rtgov.activity.model.Context;
 
@@ -393,6 +394,24 @@ public class Situation implements java.io.Externalizable {
         }
         
         return (ret);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(Object obj) {
+        if (obj instanceof Situation) {
+            return (_id.equals(((Situation)obj).getId()));
+        }
+        
+        return (false);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        return (_id.hashCode());
     }
     
     /**

--- a/modules/activity-analysis/situation-store-elasticsearch/src/main/java/org/overlord/rtgov/analytics/situation/store/elasticsearch/ElasticsearchSituationStore.java
+++ b/modules/activity-analysis/situation-store-elasticsearch/src/main/java/org/overlord/rtgov/analytics/situation/store/elasticsearch/ElasticsearchSituationStore.java
@@ -113,7 +113,7 @@ public class ElasticsearchSituationStore extends AbstractSituationStore implemen
     /**
      * {@inheritDoc}
      */
-    public void store(final Situation situation) throws Exception {
+    protected void doStore(final Situation situation) throws Exception {
         
         if (_client != null) {
             _client.add(situation.getId(), ElasticsearchClient.convertTypeToJson(situation));

--- a/modules/activity-analysis/situation-store-jpa/src/main/java/org/overlord/rtgov/analytics/situation/store/jpa/JPASituationStore.java
+++ b/modules/activity-analysis/situation-store-jpa/src/main/java/org/overlord/rtgov/analytics/situation/store/jpa/JPASituationStore.java
@@ -70,7 +70,7 @@ public class JPASituationStore extends AbstractSituationStore implements Situati
     /**
      * {@inheritDoc}
      */
-    public void store(final Situation situation) throws Exception {
+    protected void doStore(final Situation situation) throws Exception {
         _jpaStore.withJpa(new JpaWork<Void>() {
             public Void perform(Session s) {
                 if (LOG.isLoggable(Level.FINEST)) {

--- a/modules/activity-analysis/situation-store-mem/src/main/java/org/overlord/rtgov/analytics/situation/store/mem/MemSituationStore.java
+++ b/modules/activity-analysis/situation-store-mem/src/main/java/org/overlord/rtgov/analytics/situation/store/mem/MemSituationStore.java
@@ -39,7 +39,7 @@ public class MemSituationStore extends AbstractSituationStore implements Situati
     /**
      * {@inheritDoc}
      */
-    public void store(Situation situation) {
+    protected void doStore(Situation situation) {
         _situations.add(situation);
     }
     

--- a/modules/activity-analysis/situation-store/src/main/java/org/overlord/rtgov/analytics/situation/store/SituationStore.java
+++ b/modules/activity-analysis/situation-store/src/main/java/org/overlord/rtgov/analytics/situation/store/SituationStore.java
@@ -147,4 +147,12 @@ public interface SituationStore {
      * @return The number of deleted situations
      */
     public int delete(SituationsQuery query);
+    
+    /**
+     * This method deletes the supplied situation.
+     * 
+     * @param situation The situation
+     */
+    public void delete(Situation situation);
+    
 }

--- a/modules/activity-management/activity/src/main/java/org/overlord/rtgov/activity/model/ActivityType.java
+++ b/modules/activity-management/activity/src/main/java/org/overlord/rtgov/activity/model/ActivityType.java
@@ -83,6 +83,11 @@ public abstract class ActivityType implements java.io.Externalizable {
      */
     public static final String HEADER_FORMAT_PROPERTY_PREFIX="_header-format_";
 
+    /**
+     * Property representing a RTGov header value.
+     */
+    public static final String RTGOV_PROPERTY_PREFIX="_rtgov_";
+
     private String _unitId=null;
     private int _unitIndex=0;
     

--- a/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/SituationsPage.java
+++ b/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/SituationsPage.java
@@ -21,7 +21,6 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.nav.client.local.Page;
 import org.jboss.errai.ui.nav.client.local.PageHiding;
-import org.jboss.errai.ui.nav.client.local.PageShown;
 import org.jboss.errai.ui.nav.client.local.TransitionAnchor;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -475,7 +474,7 @@ public class SituationsPage extends AbstractPage {
             @Override
             public void doOnComplete(
                     org.overlord.rtgov.ui.client.local.services.rpc.IRpcServiceInvocationHandler.RpcResult<Integer> result) {
-                doSearch();
+                situationsTable.clear();
             }
 
         });

--- a/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/situations/SituationTable.java
+++ b/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/situations/SituationTable.java
@@ -88,10 +88,26 @@ public class SituationTable extends SortableTemplatedWidgetTable {
         DateTimeFormat format = DateTimeFormat.getFormat(i18n.format("dateTime-format")); //$NON-NLS-1$
 
         FlowPanel icon = new FlowPanel();
-        icon.getElement().setClassName("icon"); //$NON-NLS-1$
-        icon.getElement().addClassName("icon-severity-" + situationSummaryBean.getSeverity()); //$NON-NLS-1$
+        
+        com.google.gwt.user.client.ui.Label iconLabel=new com.google.gwt.user.client.ui.Label();
+        iconLabel.getElement().setClassName("icon"); //$NON-NLS-1$
+        iconLabel.getElement().addClassName("icon-severity-" + situationSummaryBean.getSeverity()); //$NON-NLS-1$
+        
+        icon.add(iconLabel);
+        
+        if (situationSummaryBean.getResubmissionFailureTotalCount() > 0) {
+            String text="<font color=\"red\">["+situationSummaryBean.getResubmissionFailureTotalCount()+"]</font>";
+            
+            com.google.gwt.user.client.ui.HTML html=new com.google.gwt.user.client.ui.HTML();
+            
+            html.setHTML(text);
+            
+            icon.add(html);
+        }        
+        
         Anchor type = toDetailsPageLinkFactory.get("id", situationSummaryBean.getSituationId()); //$NON-NLS-1$
         type.setText(situationSummaryBean.getType());
+        
         InlineLabel resolutionState = new InlineLabel(situationSummaryBean.getResolutionState());
         InlineLabel subject = new InlineLabel(situationSummaryBean.getSubject());
         InlineLabel description = new InlineLabel(situationSummaryBean.getDescription());

--- a/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/situations/UnsortableSituationTable.java
+++ b/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/pages/situations/UnsortableSituationTable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.rtgov.ui.client.local.pages.situations;
+
+import javax.enterprise.context.Dependent;
+
+/**
+ * A table of situations that cannot be sorted.
+ *
+ */
+@Dependent
+public class UnsortableSituationTable extends SituationTable {
+
+    /**
+     * Constructor.
+     */
+    public UnsortableSituationTable() {
+    }
+
+    /**
+     * @see org.overlord.rtgov.ui.client.local.widgets.common.SortableTemplatedWidgetTable#configureColumnSorting()
+     */
+    @Override
+    protected void configureColumnSorting() {
+    }
+
+}

--- a/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/site/situationDetails.html
+++ b/ui/overlord-rtgov-ui-base/src/main/java/org/overlord/rtgov/ui/client/local/site/situationDetails.html
@@ -66,6 +66,7 @@
               <li class="active"><a href="#details" data-toggle="tab" data-i18n-key="details">Details</a></li>
               <li><a href="#calltrace" data-toggle="tab" data-i18n-key="call-trace">Call Trace</a></li>
               <li><a href="#message" data-toggle="tab" data-field="messageTab" data-i18n-key="message">Message</a></li>
+              <li><a href="#resubmitfailures" data-toggle="tab" data-field="resubmitFailuresTab" data-i18n-key="resubmit-failures">Resubmit Failures</a></li>
             </ul>
             <div class="tab-content">
               <!-- Tab: Details -->
@@ -85,6 +86,7 @@
                     <div class="details-meta-data-section-label" data-i18n-key="application">Timestamp:</div>
                     <div data-field="timestamp" class="details-meta-data-section-value" data-role="dummy">urn:jboss:demos:applications</div>
                     <div class="clearfix"></div>
+					<button data-field="btn-resubmitted-situation" class="btn" name="ResubmittedSituation" data-i18n-key="resubmitted-situation">Resubmitted Situation</button>                    <div class="clearfix"></div>
                     <div class="divider-20"></div>
                     <div class="details-meta-data-section-header" data-i18n-key="description">Description</div>
                     <div class="clearfix"></div>
@@ -263,6 +265,70 @@
               </div>
               <!-- /Tab:Message -->
               
+              <!-- Tab:ResubmitFailures -->
+              <div class="container-fluid tab-pane fade" id="resubmitfailures">
+ 
+                <div class="clearfix"></div>
+                <div class="span12">
+                  <div class="row-fluid situations">
+                    <table data-field="resubmit-failures-table" class="overlord-table table table-striped table-condensed table-hover">
+                    <thead>
+                      <tr>
+                        <th data-i18n-key="severity-column"><!-- Severity (icon) -->!</th>
+                        <th data-i18n-key="type">Type</th>
+                        <th data-i18n-key="resolutionState">Status</th>
+                        <th data-i18n-key="subject">Subject</th>
+                        <th data-i18n-key="timestamp">Timestamp</th>
+                        <th data-i18n-key="description">Description</th>
+                        <th style="width: 38px"></th>
+                      </tr>
+                    </thead>
+                    <tbody data-role="dummy">
+                      <tr>
+                        <td><div class="icon icon-severity-critical"></div></td>
+                        <td><a href="situationDetails.html">Rate Limit Exceeded</a></td>
+                        <td>Open</td>
+                        <td>{urn:namespace}ImportantService|VeryImportantOperation</td>
+                        <td>08/20/2013 @ 5:22:47</td>
+                        <td>Some description of the Situation goes here in this column so that it can be read by the user.</td>
+                        <td>
+                          <div>
+                            <a href="#" data-toggle="popover" data-placement="left" data-html="true" data-original-title="Properties" data-trigger="hover" data-content="&lt;table class='table table-condensed table-hover table-striped' style='border-right: 1px solid rgb(211, 211, 211); border-bottom: 1px solid rgb(211, 211, 211);'>&lt;tbody>&lt;tr>&lt;td>Property 1:&lt;/td>&lt;td>Property One Value&lt;/td>&lt;/tr>&lt;tr>&lt;td>Property 2:&lt;/td>&lt;td>Property Two Value&lt;/td>&lt;/tr>&lt;/tbody>&lt;/table>"><div class="icon icon-properties"></div></a>
+                            <a href="#" data-toggle="popover" data-placement="left" data-html="true" data-original-title="Context" data-trigger="hover" data-content="&lt;table class='table table-condensed table-hover table-striped' style='border-right: 1px solid rgb(211, 211, 211); border-bottom: 1px solid rgb(211, 211, 211);'>&lt;tbody>&lt;tr>&lt;td>Context 1:&lt;/td>&lt;td>Context One Value&lt;/td>&lt;/tr>&lt;tr>&lt;td>Context 2:&lt;/td>&lt;td>Context Two Value&lt;/td>&lt;/tr>&lt;/tbody>&lt;/table>"><div class="icon icon-context"></div></a>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><div class="icon icon-severity-high"></div></td>
+                        <td><a href="situationDetails.html">SLA Violation</a></td>
+                        <td>In Progress</td>
+                        <td>{urn:namespace}ServiceA|OperationB</td>
+                        <td>08/19/2013 @ 14:33:47</td>
+                        <td>Some description of the Situation goes here in this column so that it can be read by the user.</td>
+                      </tr>
+                      <tr>
+                        <td><div class="icon icon-severity-high"></div></td>
+                        <td><a href="situationDetails.html">SLA Violation</a></td>
+                        <td>Reopened</td>
+                        <td>{urn:namespace}ServiceA|OperationB</td>
+                        <td>08/19/2013 @ 14:35:47</td>
+                        <td>Some description of the Situation goes here in this column so that it can be read by the user.</td>
+                      </tr>
+                      <tr>
+                        <td><div class="icon icon-severity-low"></div></td>
+                        <td><a href="situationDetails.html">Rate Limit Approaching</a></td>
+                        <td>Closed</td>
+                        <td>{urn:namespace}SomeService|AnotherOperation</td>
+                        <td>08/15/2013 @ 12:11:42</td>
+                        <td>Some description of the Situation goes here in this column so that it can be read by the user.</td>
+                      </tr>
+                    </tbody>
+                    </table>
+                  </div>
+                </div>
+              
+              </div>
+              <!-- /Tab:ResubmitFailures -->
             </div>
             <!-- /tab-content -->
           </div>  <!-- /situation-details -->

--- a/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationBean.java
+++ b/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationBean.java
@@ -42,13 +42,15 @@ public class SituationBean extends SituationSummaryBean implements Serializable 
     private boolean assignedToCurrentUser;
     private boolean takeoverPossible;
     private boolean resubmitPossible;
+    private String resubmittedSituationId;
+    private java.util.List<SituationSummaryBean> resubmitSituations = new java.util.ArrayList<SituationSummaryBean>();
 
     /**
      * Constructor.
      */
     public SituationBean() {
     }
-
+    
     /**
      * @return the context
      */
@@ -186,5 +188,37 @@ public class SituationBean extends SituationSummaryBean implements Serializable 
      */
     public void setResubmitPossible(boolean isResubmitPossible) {
         this.resubmitPossible = isResubmitPossible;
+    }
+    
+    /**
+     * This method sets the resubmitted situation id.
+     * 
+     * @param id The resubmitted situation id
+     */
+    public void setResubmittedSituationId(String id) {
+        this.resubmittedSituationId = id;
+    }
+    
+    /**
+     * This method returns the resubmitted situation id.
+     * 
+     * @return The resubmitted situation id
+     */
+    public String getResubmittedSituationId() {
+        return (this.resubmittedSituationId);
+    }
+
+    /**
+     * @return the situations caused by a resubmit on this situation
+     */
+    public java.util.List<SituationSummaryBean> getResubmitSituations() {
+        return resubmitSituations;
+    }
+
+    /**
+     * @param resubmitSituations the situations caused by a resubmit on this situation
+     */
+    public void setResubmitSituations(java.util.List<SituationSummaryBean> resubmitSituations) {
+        this.resubmitSituations = resubmitSituations;
     }
 }

--- a/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationSummaryBean.java
+++ b/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationSummaryBean.java
@@ -39,6 +39,7 @@ public class SituationSummaryBean {
     private Date timestamp;
     private String description;
     private Map<String, String> properties = new HashMap<String, String>();
+    private int resubmissionFailureTotalCount;
 
     /**
      * Constructor.
@@ -94,6 +95,13 @@ public class SituationSummaryBean {
     public Map<String, String> getProperties() {
         return properties;
     }
+    
+    /**
+     * @return the resubmission failure total count
+     */
+    public int getResubmissionFailureTotalCount() {
+        return resubmissionFailureTotalCount;
+    }
 
     /**
      * @param situationId the situationId to set
@@ -144,6 +152,13 @@ public class SituationSummaryBean {
         this.properties = properties;
     }
 
+    /**
+     * @param count the total count of resubmission failures
+     */
+    public void setResubmissionFailureTotalCount(int count) {
+        this.resubmissionFailureTotalCount = count;
+    }
+    
     /**
 	 * @return the resolutionState
 	 */

--- a/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationsFilterBean.java
+++ b/ui/rtgov-ui-core/src/main/java/org/overlord/rtgov/ui/client/model/SituationsFilterBean.java
@@ -36,6 +36,7 @@ public class SituationsFilterBean {
     private String description;
     private String subject;
     private String properties;
+    private boolean rootOnly=true;
 
     /**
      * Constructor.
@@ -100,6 +101,13 @@ public class SituationsFilterBean {
     }
 
     /**
+     * @return whether only root situations
+     */
+    public boolean isRootOnly() {
+        return rootOnly;
+    }
+    
+    /**
      * @param severity the severity to set
      */
     public SituationsFilterBean setSeverity(String severity) {
@@ -160,6 +168,14 @@ public class SituationsFilterBean {
      */
     public SituationsFilterBean setProperties(String host) {
         this.properties = host;
+        return this;
+    }
+    
+    /**
+     * @param b whether root situations only
+     */
+    public SituationsFilterBean setRootOnly(boolean b) {
+        this.rootOnly = b;
         return this;
     }
 

--- a/ui/rtgov-ui-situations/src/main/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsProvider.java
+++ b/ui/rtgov-ui-situations/src/main/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsProvider.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -288,12 +290,21 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
         ArrayList<SituationSummaryBean> situations = new ArrayList<SituationSummaryBean>();
 
         try {
-        	SituationsQuery query=createQuery(filters);
-        	
-	    	java.util.List<Situation> results=_situationStore.getSituations(query);
+	    	java.util.List<Situation> results=querySituations(filters);
 	
 	    	for (Situation item : results) {
-	        	situations.add(RTGovSituationsUtil.getSituationBean(item));
+	    	    // Check if only root nodes, and if so filter out situations that
+	    	    // have been resubmitted
+	    	    if (!filters.isRootOnly()
+	    	            || !item.getProperties().containsKey(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID)) {
+	    	        SituationSummaryBean ssb=RTGovSituationsUtil.getSituationBean(item);
+	    	        
+	    	        // Identify resubmission failures
+	    	        java.util.List<Situation> resubmitted=getResubmittedSituations(item.getId(), true);
+	    	        ssb.setResubmissionFailureTotalCount(resubmitted.size());
+                    
+                    situations.add(ssb);	    	        
+	    	    }
 	        }
         } catch (Exception e) {
         	throw new UiException(e);
@@ -359,7 +370,28 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
 
 	        CallTraceBean callTrace = getCallTrace(situation);
 	        ret.setCallTrace(callTrace);
-	        ret.setResubmitPossible(any(_providers, new IsResubmitSupported(situation)));
+	        
+	        // Check if other situations have been created based on the
+	        // resubmission of this situation's message
+	        java.util.List<Situation> resubsits=getResubmittedSituations(situationId, true);
+	        
+	        // If resubmit situations exist, then resubmit of this situation is not possible
+	        if (resubsits.size() == 0) {
+	            ret.setResubmitPossible(any(_providers, new IsResubmitSupported(situation)));
+	        } else {
+	            // Sort list of situations by timestamp
+	            Collections.sort(resubsits, new Comparator<Situation>() {
+
+	                @Override
+	                public int compare(Situation o1, Situation o2) {
+	                    return (int)(o1.getTimestamp() - o2.getTimestamp());
+	                }
+	            });
+	            
+	            for (Situation item : resubsits) {
+	                ret.getResubmitSituations().add(RTGovSituationsUtil.getSituationBean(item));
+	            }
+	        }
 
     	} catch (UiException uie) {
     		throw uie;
@@ -369,6 +401,56 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
     	}
 
     	return (ret);
+    }
+    
+    /**
+     * This method returns the resubmitted situations.
+     * 
+     * @param situationId The parent situation id
+     * @param deep Whether to traverse the tree (true) or just return the immediate child situations (false)
+     * @return The list of resubmitted situations
+     */
+    protected java.util.List<Situation> getResubmittedSituations(String situationId, boolean deep) {
+        java.util.List<Situation> results=new java.util.ArrayList<Situation>();
+        
+        queryResubmittedSituations(situationId, deep, results);
+        
+        return (results);
+    }
+    
+    /**
+     * This method queries the situation store to obtain situations resubmitted
+     * by the situation associated with the supplied id.
+     * 
+     * @param situationId The parent situation id
+     * @param deep Whether this should be done recursively
+     * @param results The list of situations
+     */
+    protected void queryResubmittedSituations(String situationId, boolean deep,
+                                        java.util.List<Situation> results) {
+        SituationsQuery query=new SituationsQuery();
+        query.getProperties().put(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID, situationId);
+        
+        java.util.List<Situation> resubmitted=_situationStore.getSituations(query);
+        
+        for (Situation sit : resubmitted) {
+            
+            // Need to double check id, as fuzzy 'like' used when retrieving situations based on
+            // properties to enable partial strings to be provided.
+            if (!sit.getSituationProperties().containsKey(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID)
+                    || !sit.getSituationProperties().get(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID)
+                                .equals(situationId)) {
+                continue;
+            }
+            
+            if (!results.contains(sit)) {
+                results.add(sit);
+
+                if (deep) {
+                    queryResubmittedSituations(sit.getId(), deep, results);
+                }
+            }
+        }
     }
 
     /**
@@ -553,6 +635,21 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
         if (situation == null) {
             throw new UiException(i18n.format("RTGovSituationsProvider.SitNotFound", situationId)); //$NON-NLS-1$
         }
+        
+        // RTGOV-645 - include situation id, assignTo and resolutionState in resubmission, in case
+        // further failures (resulting in linked situations) occur.
+        message.getHeaders().put(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID, situationId);
+        
+        if (situation.getSituationProperties().containsKey("assignedTo")) {
+            message.getHeaders().put(RTGovSituationsUtil.HEADER_ASSIGNED_TO,
+                    situation.getSituationProperties().get("assignedTo"));
+        }
+        
+        if (situation.getSituationProperties().containsKey("resolutionState")) {
+            message.getHeaders().put(RTGovSituationsUtil.HEADER_RESOLUTION_STATE,
+                    situation.getSituationProperties().get("resolutionState"));
+        }
+        
         resubmitInternal(situation, message, username);
     }
 
@@ -587,9 +684,17 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
     @Override
     public BatchRetryResult resubmit(SituationsFilterBean situationsFilterBean, String username) throws UiException {
         int processedCount = 0, failedCount = 0, ignoredCount = 0;
-        List<Situation> situationIdToactivityTypeIds = _situationStore
-                .getSituations(createQuery(situationsFilterBean));
+        List<Situation> situationIdToactivityTypeIds = querySituations(situationsFilterBean);
         for (Situation situation : situationIdToactivityTypeIds) {
+            // Check if situation is root, and has resubmission failures
+            if (situationsFilterBean.isRootOnly()) {
+                java.util.List<Situation> resubmits=getResubmittedSituations(situation.getId(), true);
+                
+                if (resubmits.size() > 0) {
+                    situation = resubmits.get(resubmits.size()-1);
+                }
+            }
+            
             MessageBean message = getMessage(situation);
             if (message == null) {
                 ignoredCount++;
@@ -608,11 +713,19 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
     
     @Override
     public void export(SituationsFilterBean situationsFilterBean, OutputStream outputStream) {
-        List<Situation> situationIdToactivityTypeIds = _situationStore
-                .getSituations(createQuery(situationsFilterBean));
+        List<Situation> situations = querySituations(situationsFilterBean);
         PrintWriter printWriter = new PrintWriter(outputStream);
         try {
-            for (Situation situation : situationIdToactivityTypeIds) {
+            for (Situation situation : situations) {
+                // Check if situation is root, and has resubmission failures
+                if (situationsFilterBean.isRootOnly()) {
+                    java.util.List<Situation> resubmits=getResubmittedSituations(situation.getId(), true);
+                    
+                    if (resubmits.size() > 0) {
+                        situation = resubmits.get(resubmits.size()-1);
+                    }
+                }
+                
                 MessageBean message = getMessage(situation);
                 if (message == null) {
                     continue;
@@ -657,38 +770,174 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
 	public void removed(Object key, Object value) {
 	}
 
+	/**
+	 * This method returns the root situation associated with
+	 * a resubmit hierarchy (i.e. where one situation is created
+	 * as the result of a resubmission failure from a previous
+	 * situation).
+	 * 
+	 * @param situationId The situation id
+	 * @return The root situation, or null if this situation does
+	 *        not have a resubmitted situation
+	 */
+	protected Situation getRootSituation(String situationId) throws UiException {
+	    return (getRootSituation(_situationStore.getSituation(situationId)));
+	}
+	
+    /**
+     * This method returns the root situation associated with
+     * a resubmit hierarchy (i.e. where one situation is created
+     * as the result of a resubmission failure from a previous
+     * situation).
+     * 
+     * @param original The original situation
+     * @return The root situation, or null if this situation does
+     *        not have a resubmitted situation
+     */
+    protected Situation getRootSituation(Situation original) throws UiException {
+	    Situation root=original;
+	    
+	    if (original != null) {
+	        String parentId=original.getProperties().get(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID);
+	        
+	        while (parentId != null) {
+	            root = _situationStore.getSituation(parentId);
+	            
+	            if (root == null) {
+	                // Failed to retrieve parent situation
+	                throw new UiException("Failed to locate parent situation");
+	            }
+	            
+	            parentId = root.getProperties().get(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID);
+	        }
+	    }
+	    
+	    return (root);
+	}
+	
 	@Override
-	public void assign(String situationId,String userName) throws UiException {
-		try {
-			_situationStore.assignSituation(situationId, userName);
-		} catch (Exception e) {
-			throw new UiException(e);
-		}
+	public void assign(String situationId, final String userName) throws UiException {
+        SituationsAction action=new SituationsAction() {
+            @Override
+            public void perform(Situation situation) throws Exception {
+                _situationStore.assignSituation(situation.getId(), userName);
+            }
+        };
+        
+        Situation root=getRootSituation(situationId);
+        
+        if (root != null) {        
+            try {
+                performAction(root, action);
+            } catch (UiException uie) {
+                throw uie;
+            } catch (Exception e) {
+                throw new UiException(e);
+            }
+        }
 	}
 
 	@Override
 	public void unassign(String situationId) throws UiException {
-		try {
-			_situationStore.unassignSituation(situationId);
-		} catch (Exception e) {
-			throw new UiException(e);
-		}
+        SituationsAction action=new SituationsAction() {
+            @Override
+            public void perform(Situation situation) throws Exception {
+                _situationStore.unassignSituation(situation.getId());
+            }
+        };
+        
+        Situation root=getRootSituation(situationId);
+        
+        if (root != null) {
+            try {
+                performAction(root, action);
+            } catch (UiException uie) {
+                throw uie;
+            } catch (Exception e) {
+                throw new UiException(e);
+            }
+        }
 	}
 
 	@Override
-	public void updateResolutionState(String situationId, ResolutionState resolutionState) throws UiException {
-		try {
-			_situationStore.updateResolutionState(situationId,
-			       org.overlord.rtgov.analytics.situation.store.ResolutionState.valueOf(resolutionState.name()));
-		} catch (Exception e) {
-			throw new UiException(e);
-		}
+	public void updateResolutionState(String situationId, final ResolutionState resolutionState) throws UiException {
+	    SituationsAction action=new SituationsAction() {
+            @Override
+            public void perform(Situation situation) throws Exception {
+                _situationStore.updateResolutionState(situation.getId(),
+                        org.overlord.rtgov.analytics.situation.store.ResolutionState.valueOf(resolutionState.name()));
+            }
+	    };
+	    
+        Situation root=getRootSituation(situationId);
+        
+        if (root != null) {
+            try {
+                performAction(root, action);
+            } catch (UiException uie) {
+                throw uie;
+            } catch (Exception e) {
+                throw new UiException(e);
+            }
+        }
+	}
+
+	protected void performAction(Situation root, SituationsAction action) throws Exception {
+	    action.perform(root);
+	    
+	    // Check if situation has child situations
+	    java.util.List<Situation> resubmitted=getResubmittedSituations(root.getId(), true);
+	    
+	    for (Situation sit : resubmitted) {
+	        action.perform(sit);
+	    }
+	}
+	
+	protected java.util.List<Situation> querySituations(SituationsFilterBean situationsFilterBean) {	    
+        SituationsQuery query=createQuery(situationsFilterBean);
+        
+        java.util.List<Situation> results=_situationStore.getSituations(query);
+        
+        // Check if only root situations should be returned
+        if (situationsFilterBean.isRootOnly()) {
+            for (int i=results.size()-1; i >= 0; i--) {
+                if (results.get(i).getProperties().containsKey(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID)) {
+                    results.remove(i);
+                }
+            }
+        }
+        
+        return (results);
 	}
 	
     @Override
     public int delete(SituationsFilterBean situationsFilterBean) throws UiException {
         try {
-            return _situationStore.delete(createQuery(situationsFilterBean));
+            final java.util.List<Situation> results=querySituations(situationsFilterBean);
+            final java.util.Set<Situation> deletions=new java.util.HashSet<Situation>();
+
+            for (Situation sit : results) {
+                Situation root=sit;
+                
+                if (!situationsFilterBean.isRootOnly()) {
+                    root = getRootSituation(sit);
+                }
+                
+                deletions.add(root);
+                
+                java.util.List<Situation> resubmitted=getResubmittedSituations(root.getId(), true);
+                
+                deletions.addAll(resubmitted);
+            }
+            
+            int count=0;
+            
+            for (Situation sit : deletions) {
+                _situationStore.delete(sit);
+                count++;
+            }
+
+            return (count);
         } catch (Exception e) {
             throw new UiException(e);
         }
@@ -816,5 +1065,20 @@ public class RTGovSituationsProvider implements SituationsProvider, ActiveChange
             return operation;
         }
 
+    }
+    
+    /**
+     * Interface for performing an action on a situation.
+     *
+     */
+    public interface SituationsAction {
+
+        /**
+         * This method performs the action on a specified situation.
+         * 
+         * @param situation The situation
+         * @throws Exception Failed to perform action
+         */
+        public void perform(Situation situation) throws Exception;
     }
 }

--- a/ui/rtgov-ui-situations/src/main/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsUtil.java
+++ b/ui/rtgov-ui-situations/src/main/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsUtil.java
@@ -17,6 +17,7 @@ package org.overlord.rtgov.ui.provider.situations;
 
 import java.util.Date;
 
+import org.overlord.rtgov.activity.model.ActivityType;
 import org.overlord.rtgov.activity.model.Context;
 import org.overlord.rtgov.analytics.situation.Situation;
 import org.overlord.rtgov.ui.client.model.NameValuePairBean;
@@ -33,6 +34,23 @@ public class RTGovSituationsUtil {
      * Prefix identifying internal properties.
      */
     public static final String INTERNAL_PROPERTY_PREFIX="_";
+
+    /**
+     * The property name used to defined the resubmitted sitation id.
+     */
+    public static final String HEADER_RESUBMITTED_SITUATION_ID = ActivityType.RTGOV_PROPERTY_PREFIX+"resubmittedSituationId";
+
+    /**
+     * The property name used to defined the "assigned to" value.
+     */
+    public static final String HEADER_ASSIGNED_TO = ActivityType.RTGOV_PROPERTY_PREFIX+Situation.class.getSimpleName()
+                                    +INTERNAL_PROPERTY_PREFIX+"assignedTo";
+
+    /**
+     * The property name used to defined the "resolutionState" value.
+     */
+    public static final String HEADER_RESOLUTION_STATE = ActivityType.RTGOV_PROPERTY_PREFIX+Situation.class.getSimpleName()
+                                    +INTERNAL_PROPERTY_PREFIX+"resolutionState";
 
     /**
      * Constructor.
@@ -75,6 +93,8 @@ public class RTGovSituationsUtil {
     	                        context.getValue()));
     	    }
     	}
+    	
+    	ret.setResubmittedSituationId(situation.getProperties().get(HEADER_RESUBMITTED_SITUATION_ID));
 
     	return (ret);
     }

--- a/ui/rtgov-ui-situations/src/test/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsProviderTest.java
+++ b/ui/rtgov-ui-situations/src/test/java/org/overlord/rtgov/ui/provider/situations/RTGovSituationsProviderTest.java
@@ -134,13 +134,18 @@ public class RTGovSituationsProviderTest {
 				throw new AssertionError("Fail");
 			}
 			public java.util.List<Situation> getSituations(SituationsQuery query) {
-				if (!query.getType().equals(TEST_TYPE)) {
-					throw new AssertionError("Unexpected query type: "+query.getType());
-				}
-				Situation s1=new Situation();
-				s1.setSubject(TEST_SUBJECT);
-				java.util.List<Situation> ret=new java.util.ArrayList<Situation>();
-				ret.add(s1);
+                java.util.List<Situation> ret=new java.util.ArrayList<Situation>();
+			    if (query.getType() == null
+			            && query.getProperties().containsKey(RTGovSituationsUtil.HEADER_RESUBMITTED_SITUATION_ID)) {
+			        // Resubmission failure query so ignore
+			    } else {
+    				if (!query.getType().equals(TEST_TYPE)) {
+    					throw new AssertionError("Unexpected query type: "+query.getType());
+    				}
+    				Situation s1=new Situation();
+    				s1.setSubject(TEST_SUBJECT);
+    				ret.add(s1);
+			    }
 				return (ret);
 			}
 			public void assignSituation(String situationId, String userName) throws Exception {
@@ -163,6 +168,8 @@ public class RTGovSituationsProviderTest {
 
             public int delete(SituationsQuery query) {
                 return 0;
+            };
+            public void delete(Situation sit) {
             };
             public void store(Situation situation) throws Exception {
             };
@@ -263,7 +270,7 @@ public class RTGovSituationsProviderTest {
 				return (ret);
 			}
 			public java.util.List<Situation> getSituations(SituationsQuery query) {
-				throw new AssertionError("Fail");
+				return java.util.Collections.<Situation>emptyList();
 			}
 			public void assignSituation(String situationId, String userName) throws Exception {
 				throw new Exception("Fail");
@@ -285,6 +292,8 @@ public class RTGovSituationsProviderTest {
             public int delete(SituationsQuery query) {
                 return 0;
             }
+            public void delete(Situation sit) {
+            };
             public void store(Situation situation) throws Exception {
             };
 		};


### PR DESCRIPTION
...onState via resubmitted business transaction header properties, which can then be conveyed via activity events (and subsequent linked situations). Update UI to only list 'root' situations, include button for navigating to parent situation, and separate situation tab for listing situations that resulted from resubmission failures. Changes to assignment and resolution state updates to apply to situation hierarchy. Deletion now deletes complete tree of situations based on the filtered 'root' situations.