### PR TITLE
RTGOV-650 Consider swyd npe to be a valid response, so need to clear the...

### DIFF
--- a/ui/rtgov-ui-services-switchyard/src/main/java/org/overlord/rtgov/ui/provider/switchyard/SwitchYardResubmitActionProvider.java
+++ b/ui/rtgov-ui-services-switchyard/src/main/java/org/overlord/rtgov/ui/provider/switchyard/SwitchYardResubmitActionProvider.java
@@ -138,6 +138,16 @@ public class SwitchYardResubmitActionProvider extends ResubmitActionProvider {
 					LOG.fine("Remote invocation of switchyard service["+service+"] operation["
 							+operation+"] failed to deserialize response");
 				}
+
+				// RTGOV-650 Assume that response means successful resubmission, as due to npe
+				// we currently have no visibility of the response to determine either way.
+				// If the response indicates an error, this should result in another Situation
+				// being created, thus resetting the resolution state to IN_PROGRESS anyway.
+				
+				// Clear previous exceptions
+				exc = null;
+
+				break;
 			} catch (java.io.IOException e) {
 				exc = e;
 			}


### PR DESCRIPTION
... exception - if further situations are created this will set the state back to IN_PROGRESS. Only issue with this approach is if the remote swyd server does not have the resubmitted service deployed, as this also causes npe, and currently causes the state to remain RESOLVED.